### PR TITLE
Update nixpkgs to version 24.11

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,9 @@
 {
   inputs = {
-    nixpkgs.url = github:NixOS/nixpkgs/nixos-24.05;
+    nixpkgs.url = github:NixOS/nixpkgs/nixos-24.11;
     flake-utils.url = github:numtide/flake-utils;
     home-manager = {
-      url = github:nix-community/home-manager/release-24.05;
+      url = github:nix-community/home-manager/release-24.11;
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };


### PR DESCRIPTION
Hi,

I just bumped the version of nixpkgs to [24.11](https://nixos.org/blog/announcements/2024/nixos-2411/), the latest stable release.

Nice tool, thanks.